### PR TITLE
feat: add VALIDATOR_ID env var to validator statefulset

### DIFF
--- a/charts/validator/Chart.yaml
+++ b/charts/validator/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Flashnet validator
 
 type: application
 
-version: 0.1.0
+version: 0.1.1
 
 appVersion: "0.0.1"
 

--- a/charts/validator/templates/statefulset.yaml
+++ b/charts/validator/templates/statefulset.yaml
@@ -123,6 +123,8 @@ spec:
               value: {{ $.Values.config.runningAuthority }}
             - name: TEE_CRYPTO_MODULE_PUBLIC_KEY
               value: {{ range $i, $e := $.Values.config.teeCryptoModulePublicKey }}{{ if $i }},{{ end }}{{ $e }}{{ end }}
+            - name: VALIDATOR_ID
+              value: {{ range $i, $e := $.Values.config.validatorId }}{{ if $i }},{{ end }}{{ $e }}{{ end }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/validator/values.yaml
+++ b/charts/validator/values.yaml
@@ -54,6 +54,7 @@ config:
   signingKey: []
   runningAuthority: "<YOUR_RUNNING_AUTHORITY>"
   teeCryptoModulePublicKey: []
+  validatorId: []  # Validator UUIDs from database registry (comma-separated in env)
 
 env:
   - name: RUST_LOG


### PR DESCRIPTION
This pull request makes a small change to the `charts/validator/templates/statefulset.yaml` file by adding a new environment variable to the validator container specification.

- Added the `VALIDATOR_ID` environment variable, which is populated from the `config.validatorId` values in the Helm chart.