### PR TITLE
feat(validator): add PostgreSQL dual-write env vars

### DIFF
--- a/charts/validator/Chart.yaml
+++ b/charts/validator/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Flashnet validator
 
 type: application
 
-version: 0.1.1
+version: 0.1.2
 
 appVersion: "0.0.1"
 

--- a/charts/validator/templates/statefulset.yaml
+++ b/charts/validator/templates/statefulset.yaml
@@ -125,6 +125,14 @@ spec:
               value: {{ range $i, $e := $.Values.config.teeCryptoModulePublicKey }}{{ if $i }},{{ end }}{{ $e }}{{ end }}
             - name: VALIDATOR_ID
               value: {{ range $i, $e := $.Values.config.validatorId }}{{ if $i }},{{ end }}{{ $e }}{{ end }}
+            {{- if $.Values.config.databaseUrl }}
+            - name: DATABASE_URL
+              value: {{ $.Values.config.databaseUrl }}
+            {{- end }}
+            {{- if $.Values.config.dualWrite }}
+            - name: DUAL_WRITE
+              value: "true"
+            {{- end }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/validator/values.yaml
+++ b/charts/validator/values.yaml
@@ -55,6 +55,9 @@ config:
   runningAuthority: "<YOUR_RUNNING_AUTHORITY>"
   teeCryptoModulePublicKey: []
   validatorId: []  # Validator UUIDs from database registry (comma-separated in env)
+  # PostgreSQL configuration for dual-write migration
+  databaseUrl: ""  # PostgreSQL connection URL (required when dualWrite is true)
+  dualWrite: false  # Enable dual-write mode for Redis→PostgreSQL migration
 
 env:
   - name: RUST_LOG


### PR DESCRIPTION
## Summary
- Add `DATABASE_URL` and `DUAL_WRITE` environment variables to the validator StatefulSet
- Add `config.databaseUrl` and `config.dualWrite` fields to values.yaml
- Bump chart version from 0.1.1 to 0.1.2

## Why
These env vars are required for the Redis → PostgreSQL migration with zero downtime. When `dualWrite: true`:
- Writes go to both PostgreSQL (source of truth) and Redis
- Reads prefer PostgreSQL, fall back to Redis for unmigrated keys
- A background task migrates historical data on startup

## Test plan
- [ ] Deploy to staging with `dualWrite: true` and `databaseUrl` set
- [ ] Verify validator starts and connects to both databases
- [ ] Verify background migration runs