### PR TITLE
fix(validator): support databaseUrl array as comma-separated string

### DIFF
--- a/charts/validator/templates/statefulset.yaml
+++ b/charts/validator/templates/statefulset.yaml
@@ -126,8 +126,13 @@ spec:
             - name: VALIDATOR_ID
               value: {{ range $i, $e := $.Values.config.validatorId }}{{ if $i }},{{ end }}{{ $e }}{{ end }}
             {{- if $.Values.config.databaseUrl }}
+            {{- if kindIs "slice" $.Values.config.databaseUrl }}
+            - name: DATABASE_URL
+              value: {{ range $i, $e := $.Values.config.databaseUrl }}{{ if $i }},{{ end }}{{ $e }}{{ end }}
+            {{- else }}
             - name: DATABASE_URL
               value: {{ $.Values.config.databaseUrl }}
+            {{- end }}
             {{- end }}
             {{- if $.Values.config.dualWrite }}
             - name: DUAL_WRITE


### PR DESCRIPTION
When databaseUrl is an array in values.yaml, convert it to comma-separated string (like validatorId pattern). Validator code selects the correct URL based on validator_index.

Fixes the issue where staging couldn't start because DATABASE_URL was required but not set when databaseUrl was an array.