### PR TITLE
chore(validator): bump chart version to 0.1.3

### DIFF
--- a/charts/validator/Chart.yaml
+++ b/charts/validator/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Flashnet validator
 
 type: application
 
-version: 0.1.2
+version: 0.1.3
 
 appVersion: "0.0.1"
 


### PR DESCRIPTION
0.1.2 release already exists, bumping to 0.1.3 for new release with databaseUrl array support.