### PR TITLE
feat!: remove Redis, PostgreSQL-only

### DIFF
--- a/charts/validator/Chart.lock
+++ b/charts/validator/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 2.31.1
-- name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 21.1.8
-digest: sha256:0454402aceb98b035dd34b6802c615384adb6ca31f1ba87e56f345d1739509d3
-generated: "2025-06-11T21:08:20.916551+02:00"

--- a/charts/validator/Chart.yaml
+++ b/charts/validator/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Flashnet validator
 
 type: application
 
-version: 0.1.3
+version: 0.1.4
 
 appVersion: "0.0.1"
 
@@ -14,7 +14,3 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x.x
-  - name: redis
-    version: 21.1.8
-    repository: https://charts.bitnami.com/bitnami
-    condition: redis.enabled

--- a/charts/validator/templates/statefulset.yaml
+++ b/charts/validator/templates/statefulset.yaml
@@ -57,28 +57,6 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.initContainers.enabled }}
-      initContainers:
-      - name: init-wait-redis
-        image: alpine:3.16.0
-        command: ["sh", "-c", "for i in $(seq 1 300); do nc -zvw1 $REDIS_HOST 6379 && exit 0 || sleep 3; done; exit 1"]
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsUser: 1000
-          capabilities:
-            drop:
-              - ALL
-        resources:
-            limits:
-              cpu: 20m
-              memory: 20Mi
-            requests:
-              cpu: 10m
-              memory: 10Mi
-        env:
-          - name: REDIS_HOST
-            value: {{ .Values.initContainers.redisHost | default "validator-1-redis-master" }}
-        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}
@@ -111,8 +89,6 @@ spec:
             {{- toYaml . | nindent 12 }}
             - name: GRPC_BIND_ADDRESS
               value: {{ $.Values.config.grpcBindAddress }}
-            - name: VALIDATOR_REDIS_CONNECTION_URL
-              value: {{ $.Values.config.validatorRedisConnectionUrl }}
             - name: SIGNING_KEY
               value: {{ range $i, $e := $.Values.config.signingKey }}{{ if $i }},{{ end }}{{ $e }}{{ end }}
             - name: VALIDATOR_INDEX
@@ -133,10 +109,6 @@ spec:
             - name: DATABASE_URL
               value: {{ $.Values.config.databaseUrl }}
             {{- end }}
-            {{- end }}
-            {{- if $.Values.config.dualWrite }}
-            - name: DUAL_WRITE
-              value: "true"
             {{- end }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/validator/values.yaml
+++ b/charts/validator/values.yaml
@@ -50,14 +50,11 @@ ingress:
 
 config:
   grpcBindAddress: "0.0.0.0:50059"
-  validatorRedisConnectionUrl: "redis://username:password@validator-redis-master:6379"
   signingKey: []
   runningAuthority: "<YOUR_RUNNING_AUTHORITY>"
   teeCryptoModulePublicKey: []
   validatorId: []  # Validator UUIDs from database registry (comma-separated in env)
-  # PostgreSQL configuration for dual-write migration
-  databaseUrl: ""  # PostgreSQL connection URL (required when dualWrite is true)
-  dualWrite: false  # Enable dual-write mode for Redis→PostgreSQL migration
+  databaseUrl: []  # PostgreSQL connection URLs (one per validator)
 
 env:
   - name: RUST_LOG
@@ -67,38 +64,3 @@ metrics:
   datadog:
     enabled: true
     env: production
-
-initContainers:
-  enabled: true
-  redisHost: "validator-redis-master"
-
-redis:
-  enabled: true
-  fullnameOverride: "validator-redis"  
-  global:
-    storageClass: "gp2"
-    redis:
-      password: "YourSecurePassword123!"
-  master:
-    persistence:
-      size: 8Gi
-  replica:
-    replicaCount: 1
-    persistence:
-      size: 8Gi
-  acl:
-    users:
-      - username: "default"
-        enabled: "off"
-        commands: "-@all"
-        keys: "~*"
-      - username: "username"
-        password: "password"
-        enabled: "on"
-        commands: "+@all"
-        keys: "~*"
-        channels: "&*"
-  commonConfiguration: |-
-    appendonly yes
-    save 60 1
-


### PR DESCRIPTION
## Summary

Removes Redis from the validator Helm chart. PostgreSQL is now the only storage backend.

**BREAKING CHANGE:** Redis is no longer supported.

> **Important:** Deploy this AFTER flashnet-validators PR #59 is merged.

## Removed

| Item | Description |
|------|-------------|
| `redis` dependency | Chart.yaml Redis subchart |
| `config.validatorRedisConnectionUrl` | Redis connection URL |
| `config.dualWrite` | Dual-write mode flag |
| `initContainers` | Redis wait init container |
| `redis` section | Full Redis deployment config |
| `VALIDATOR_REDIS_CONNECTION_URL` | StatefulSet env var |
| `DUAL_WRITE` | StatefulSet env var |

## Version

- Chart version: `0.1.3` → `0.1.4`

## Deployment Order

1. Merge flashnet-validators #58 (dual-write)
2. Verify PostgreSQL migration
3. Merge flashnet-validators #59 (remove Redis from code)
4. Merge this PR (remove Redis from Helm)
5. Update applicationset.yaml to use chart 0.1.4